### PR TITLE
Add community profiles

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,28 @@
+<!--
+Thanks for opening an issue! A few things to keep in mind:
+
+- The issue tracker is only for bugs and feature requests.
+- Before reporting a bug, please try reproducing your issue against the latest version of Xiaofan.
+-->
+
+### Expected behavior
+
+<!-- What do you think should happen? -->
+
+### Actual behavior
+
+<!-- What actually happens? -->
+
+### How to reproduce
+
+<!--
+
+Your best chance of getting this bug looked at quickly is to provide a REPOSITORY that can be cloned and run.
+
+You can for https://github.com/straightdave/arion and include a link to the branch with your changes.
+
+If you provide a URL, please list the commands required to clone/setup/run your repo e.g.
+
+  $ git clone $YOUR_URL -b $BRANCH
+
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,3 @@
+<!--
+Read the [contributing guidelines](https://github.com/straightdave/arion/blob/master/CONTRIBUTING.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.
+-->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at eyaswoo@gmail.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [https://contributor-covenant.org/version/1/4][version]
+
+[homepage]: https://contributor-covenant.org
+[version]: https://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing to Arion
+
+Thanks for contributing to Arion!
+
+Please note that this project is released with a [Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
+
+## How can I contribute?
+
+### Imporve documentation
+
+As a user of Arion you're the perfect candidate to help us improve our documentation. Typo corrections, error fixes, better explanations, more examples, etc. Open issues for things that could be improved. Anything. Even improvements to this document.
+
+### Improve issues
+
+Some issues are created with missing information, not reproducible, or plain invalid. Help make them easier to resolve. Handling issues takes a lot of time that we would rather spend on fixing bugs and adding features.
+
+### Give feedback on issues
+
+We're always looking for more opinions on discussions in the issue tracker. It's a good opportunity to influence the future direction of Arion.
+
+### Write code
+
+You can use issue labels to discover issues you could help out with:
+
+- [`blocked` issues](https://github.com/straightdave/arion/labels/blocked) need help getting unstuck
+- [`bug` issues](https://github.com/straightdave/arion/labels/bug) are known bugs we'd like to fix
+- [`enhancement` issues](https://github.com/straightdave/arion/labels/enhancement) are features we're open to including
+- [`performance` issues](https://github.com/straightdave/arion/labels/performance) track ideas on how to improve Arion's performance
+
+## Submitting an issue
+
+- The issue tracker is for issues.
+- Search the issue tracker before opening an issue.
+- Ensure you're using the latest version of Arion.
+- Use a clear and descriptive title.
+- Include as much information as possible: Steps to reproduce the issue, error message, client lib version, operating system, etc.
+- The more time you put into an issue, the more we will.
+- The best issue report is a failing test proving it.
+
+## Submitting a pull request
+
+- Non-trivial changes are often best discussed in an issue first, to prevent you from doing unnecessary work.
+- For ambitious tasks, you should try to get your work in front of the community for feedback as soon as possible. Open a pull request as soon as you have done the minimum needed to demonstrate your idea. At this early stage, don't worry about making things perfect, or 100% complete. Add a [WIP] prefix to the title, and describe what you still need to do. This lets reviewers know not to nit-pick small details or point out improvements you already know you need to make.
+- New features should be accompanied with tests and documentation.
+- Don't include unrelated changes.
+- Lint and test before submitting the pull request by running `$ npm test`.
+- Make the pull request from a [topic branch](https://github.com/dchelimsky/rspec/wiki/Topic-Branches), not master.
+- Use a clear and descriptive title for the pull request and commits.
+- Write a convincing description of why we should land your pull request. It's your job to convince us. Answer "why" it's needed and provide use-cases.
+- You might be asked to do changes to your pull request. There's never a need to open another pull request. [Just update the existing one](https://github.com/RichardLitt/docs/blob/master/amending-a-commit-guide.md).
+
+Note: when making code changes, try to remember Arion's mantra (forked from AVA) of having preferably one way to do something. For example, a request to add an alias to part of the API ([like this](https://github.com/avajs/ava/pull/663)) will likely be rejected without some other substantial benefit.


### PR DESCRIPTION
Add community profiles for the better open source experience.

You could refer the [Open Source Guides](https://opensource.guide/).

Added:

- Issue template
- Pull request template
- Code of conduct
- Contributing doc